### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://npm.pkg.github.com'
-          scope: '@forgebase'
+          scope: '@the-forgebase'
       
       - name: Publish to GitHub Packages
         run: |
@@ -142,7 +142,7 @@ jobs:
               cd "$pkg"
               echo "Publishing $(basename $pkg)..."
               # Update package name to use GitHub Packages scope
-              sed -i 's/"name": "@forgebase-ts\/\(.*\)"/"name": "@forgebase\/\1"/' package.json
+              sed -i 's/"name": "@forgebase-ts\/\(.*\)"/"name": "@the-forgebase\/\1"/' package.json
               npm publish --access public
               cd -
             fi


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/release.yml` file to update the scope for publishing packages. The most important changes are:

* Updated the `scope` parameter from `@forgebase` to `@the-forgebase` in the `with` section of the release workflow.
* Modified the `sed` command to update the package name to use the new GitHub Packages scope `@the-forgebase` instead of `@forgebase`.