### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,10 +44,10 @@ jobs:
         id: determine_version
         run: |
           # Check if this is the first release
-          if ! git tag | grep -q "v0"; then
-            # First release - use 0.0.0-alpha.1
-            echo "NEW_VERSION=0.0.0-alpha.1" >> $GITHUB_ENV
-          else
+          # if ! git tag | grep -q "v0"; then
+          #   # First release - use 0.0.0-alpha.1
+          #   echo "NEW_VERSION=0.0.0-alpha.1" >> $GITHUB_ENV
+          # else
             # Get the latest version tag
             LATEST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "v0.0.0-alpha.0")
             
@@ -68,7 +68,7 @@ jobs:
             fi
             
             echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-          fi
+          # fi
       
       - name: Generate Release Notes
         id: release_notes


### PR DESCRIPTION
This pull request includes changes to the release workflow in the `.github/workflows/release.yml` file to modify the version determination process.

Changes to the release workflow:

* Commented out the conditional check and assignment for the first release version (`0.0.0-alpha.1`). This change ensures that the latest version tag is always used, even for the first release. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L47-R50) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L71-R71)