### PR TITLE
Remove packageManager entry from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,6 @@
   "nx": {
     "includedScripts": []
   },
-  "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change involves removing the `packageManager` field, which specified the version and integrity hash of `pnpm`.

Change:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L187): Removed the `packageManager` field.