### PR TITLE
Update release workflow: add SDK to build process, enhance versioning…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,42 +14,42 @@ jobs:
       contents: write # Needed for creating releases
       pull-requests: read # Needed for reading PR info for release notes
       packages: write # Needed if you want to publish to GitHub Packages
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Important for determining version and generating changelogs
-      
+
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
           version: 9
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-      
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      
+
       - name: Setup Git User
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-      
+
       - name: Determine version
         id: determine_version
         run: |
           # Get the latest version tag, ensuring we fetch all tags
           git fetch --tags
           LATEST_TAG=$(git tag -l "v*" --sort=-v:refname | head -n 1 || echo "v0.0.0-alpha.0")
-            
+
           # Extract version number without the 'v' prefix
           LATEST_VERSION=${LATEST_TAG#v}
-            
+
           # If it's an alpha version, increment the alpha number
           if [[ $LATEST_VERSION == *"-alpha."* ]]; then
             PREFIX=$(echo $LATEST_VERSION | cut -d'-' -f1)
@@ -62,29 +62,29 @@ jobs:
             NEW_PATCH=$((PATCH + 1))
             NEW_VERSION="$MAJOR.$MINOR.$NEW_PATCH-alpha.1"
           fi
-            
+
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-      
+
       - name: Generate Release Notes
         id: release_notes
         run: |
           # Get the previous tag or use the initial commit if no tags exist
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || git rev-list --max-parents=0 HEAD)
-          
+
           # Generate release notes from commits since the previous tag
           echo "## Changes in this Release" > RELEASE_NOTES.md
           echo "" >> RELEASE_NOTES.md
-          
+
           # Get merged PRs since the last tag
           git log ${PREVIOUS_TAG}..HEAD --pretty=format:"* %s (%h)" | grep -i "merge pull request" >> RELEASE_NOTES.md || true
-          
+
           # If no PRs found, list regular commits
           if [ ! -s RELEASE_NOTES.md ]; then
             git log ${PREVIOUS_TAG}..HEAD --pretty=format:"* %s (%h)" >> RELEASE_NOTES.md
           fi
-          
+
           cat RELEASE_NOTES.md
-      
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
@@ -95,31 +95,31 @@ jobs:
           prerelease: true # Alpha releases are marked as pre-releases
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Update package versions
         run: |
           find ./libs -name "package.json" -type f -exec sed -i "s/\"version\": \".*\"/\"version\": \"${{ env.NEW_VERSION }}\"/g" {} \;
-      
+
       - name: Build all libraries
-        run: pnpm exec nx run-many -t build --projects=api,auth,common,database,real-time,storage
-      
+        run: pnpm exec nx run-many -t build --projects=api,auth,common,database,real-time,storage,sdk
+
       - name: Setup GitHub Package Registry
         run: |
           echo "@forgebase:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
-      
+
       # Uncomment the following steps if you want to publish packages to npm
       # - name: Setup npm authentication
       #   run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-      # 
+      #
       # - name: Build packages
       #   run: pnpm exec nx affected -t build
-      # 
+      #
       # - name: Publish to npm
       #   run: |
       #     # Update package versions
       #     find ./libs -name "package.json" -type f -exec sed -i "s/\"version\": \".*\"/\"version\": \"${{ env.NEW_VERSION }}\"/g" {} \;
-      #     
+      #
       #     # Publish packages
       #     find ./dist/libs -type d -maxdepth 1 -exec pnpm publish --access public --no-git-checks {} \;
 
@@ -129,7 +129,7 @@ jobs:
           node-version: 20
           registry-url: 'https://npm.pkg.github.com'
           scope: '@the-forgebase'
-      
+
       - name: Publish to GitHub Packages
         run: |
           for pkg in dist/libs/*; do


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/release.yml` file. The change ensures that the `sdk` project is included in the build process.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L104-R104): Added the `sdk` project to the list of projects to be built in the `run-many` command.… logic, and improve release notes generation