### PR TITLE
ci(release): update package names to use GitHub Packages scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,17 @@ jobs:
           # Update package versions
           find ./libs -name "package.json" -type f -exec sed -i "s/\"version\": \".*\"/\"version\": \"${{ env.NEW_VERSION }}\"/g" {} \;
 
+          # Change Package Name
+          for pkg in dist/libs/*; do
+            if [ -d "$pkg" ]; then
+              cd "$pkg"
+              echo "Publishing $(basename $pkg)..."
+              # Update package name to use GitHub Packages scope
+              sed -i 's/"name": "@forgebase-ts\/\(.*\)"/"name": "@the-forgebase\/\1"/' package.json
+              cd -
+            fi
+          done
+
           # Publish packages
           find ./dist/libs -type d -maxdepth 1 -exec pnpm publish --access public --no-git-checks {} \;
 


### PR DESCRIPTION
Modify the release workflow to update the package names in `package.json` files to use the GitHub Packages scope `@the-forgebase` instead of `@forgebase-ts`. This change ensures that the packages are published under the correct namespace in GitHub Packages.