### PR TITLE
ci(release): add PKG_NAME env variable to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
           fi
 
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "PKG_NAME=\"@the-forgebase\"" >> $GITHUB_ENV
 
       - name: Generate Release Notes
         id: release_notes
@@ -105,6 +106,7 @@ jobs:
           pnpm exec tsx scripts/update-internal-deps.ts
         env:
           NEW_VERSION: ${{ env.NEW_VERSION }}
+          PKG_NAME: ${{ env.PKG_NAME }}
 
       - name: Build all libraries
         run: pnpm exec nx run-many -t build --projects=api,auth,common,database,real-time,storage,sdk,web-auth,react-native-auth

--- a/scripts/update-internal-deps.ts
+++ b/scripts/update-internal-deps.ts
@@ -4,6 +4,7 @@ import { readFileSync, writeFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 
 const NEW_VERSION = process.env.NEW_VERSION || '0.0.0-alpha.17';
+const PKG_NAME = process.env.PKG_NAME || '@the-forgebase';
 const PACKAGES_TO_UPDATE = [
   '@forgebase-ts/auth',
   '@forgebase-ts/common',
@@ -25,6 +26,22 @@ function updateDeps(obj: Record<string, any> | undefined) {
   }
 }
 
+function updatePkgName(obj: Record<string, any> | undefined) {
+  if (!obj) return;
+
+  const updates: Record<string, any> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (key.startsWith('@forgebase-ts')) {
+      const newKey = key.replace('@forgebase-ts', `${PKG_NAME}`);
+      updates[newKey] = value;
+      delete obj[key];
+    }
+  }
+
+  Object.assign(obj, updates);
+}
+
 function processPackageJson(filePath: string) {
   const content = readFileSync(filePath, 'utf8');
   const json = JSON.parse(content);
@@ -33,6 +50,8 @@ function processPackageJson(filePath: string) {
 
   updateDeps(json.dependencies);
   updateDeps(json.peerDependencies);
+  updatePkgName(json.dependencies);
+  updatePkgName(json.peerDependencies);
 
   writeFileSync(filePath, JSON.stringify(json, null, 2) + '\n');
 }
@@ -52,3 +71,5 @@ function findPackageJsons(dir: string) {
 // Start
 findPackageJsons('./libs');
 console.log('Done updating internal dependencies.');
+console.log('pkg name: ', PKG_NAME);
+console.log('new version: ', NEW_VERSION);


### PR DESCRIPTION
Add PKG_NAME environment variable to the release workflow and update the update-internal-deps.ts script to handle package name updates. This ensures consistent package naming during the release process.