### PR TITLE
ci: remove unnecessary quotes from PKG_NAME in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           fi
 
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
-          echo "PKG_NAME=\"@the-forgebase\"" >> $GITHUB_ENV
+          echo "PKG_NAME=@the-forgebase" >> $GITHUB_ENV
 
       - name: Generate Release Notes
         id: release_notes

--- a/scripts/update-internal-deps.ts
+++ b/scripts/update-internal-deps.ts
@@ -33,6 +33,7 @@ function updatePkgName(obj: Record<string, any> | undefined) {
 
   for (const [key, value] of Object.entries(obj)) {
     if (key.startsWith('@forgebase-ts')) {
+      // if PKG_NAME is "@the-forgebase" then remove the quotes from the key
       const newKey = key.replace('@forgebase-ts', `${PKG_NAME}`);
       updates[newKey] = value;
       delete obj[key];
@@ -54,6 +55,10 @@ function processPackageJson(filePath: string) {
   updatePkgName(json.peerDependencies);
 
   writeFileSync(filePath, JSON.stringify(json, null, 2) + '\n');
+
+  console.log('Done updating internal dependencies.');
+  console.log('pkg name: ', PKG_NAME);
+  console.log('new version: ', NEW_VERSION);
 }
 
 function findPackageJsons(dir: string) {
@@ -70,6 +75,3 @@ function findPackageJsons(dir: string) {
 
 // Start
 findPackageJsons('./libs');
-console.log('Done updating internal dependencies.');
-console.log('pkg name: ', PKG_NAME);
-console.log('new version: ', NEW_VERSION);


### PR DESCRIPTION
The quotes around PKG_NAME in the release workflow were redundant and have been removed for consistency. Additionally, the logging statements in the update-internal-deps.ts script were moved to ensure they are executed after the process is complete.